### PR TITLE
Makefile to compile Translate grammar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,25 +7,44 @@ Translate: TranslateEng TranslateBul TranslateEus TranslateChi TranslateGer Tran
 TranslateEng: TranslateEng.pgf
 TranslateBul: TranslateBul.pgf
 TranslateChi: TranslateChi.pgf
-TranslateGer: TranslateGer.pgf
+TranslateCat: TranslateCat.pgf
 TranslateDut: TranslateDut.pgf
-TranslateSwe: TranslateSwe.pgf
-TranslateHin: TranslateHin.pgf
+TranslateEst: TranslateEst.pgf
+TranslateEus: TranslateEus.pgf
 TranslateFin: TranslateFin.pgf
 TranslateFre: TranslateFre.pgf
+TranslateGer: TranslateGer.pgf
+TranslateHin: TranslateHin.pgf
 TranslateIta: TranslateIta.pgf
+TranslateJpn: TranslateJpn.pgf
+TranslateRus: TranslateRus.pgf
 TranslateSpa: TranslateSpa.pgf
-TranslateEus: TranslateEus.pgf
+TranslateSwe: TranslateSwe.pgf
+TranslateTha: TranslateTha.pgf
+TranslateUrd: TranslateUrd.pgf
+
+all: Translate $(TRANSLATE15) $(TranslateEngSwe).pgf  $(TranslateEngSweFin) $(TranslateEngSweBul)
+
 
 S=-s
-GFMKT=mkdir -p ../translator && gf $S -make -literal=PN,Symb -probs=$(TPROBSFILE) -gfo-dir ../translator
+TGFO=dist/build/translator
+GFMKT=mkdir -p $(TGFO) && gf $S -make -literal=PN,Symb -probs=$(TPROBSFILE) -gfo-dir $(TGFO)
 
 TRANSLATE8=TranslateEng.pgf TranslateBul.pgf TranslateChi.pgf TranslateGer.pgf TranslateSwe.pgf TranslateHin.pgf TranslateFin.pgf TranslateFre.pgf
-TRANSLATE10=TranslateEng.pgf TranslateBul.pgf TranslateChi.pgf TranslateGer.pgf TranslateSwe.pgf TranslateHin.pgf TranslateFin.pgf TranslateFre.pgf TranslateIta.pgf TranslateSpa.pgf
+
+TRANSLATE10=$(TRANSLATE8) TranslateIta.pgf TranslateSpa.pgf
 
 TRANSLATE11=$(TRANSLATE10) TranslateDut.pgf
 
-TRANSLATE15=$(TRANSLATE10) TranslateDut.pgf TranslateCat.pgf TranslateEst.pgf TranslateTha.pgf TranslateJpn.pgf
+TRANSLATE15=$(TRANSLATE11) TranslateCat.pgf TranslateEst.pgf TranslateTha.pgf TranslateJpn.pgf
+
+# Without dependencies:
+Translate8:
+	$(GFMKT) -name=Translate8 $(TRANSLATE8) +RTS -K32M
+
+# With dependencies:
+Translate8.pgf: $(TRANSLATE8)
+	$(GFMKT) -name=Translate8 $(TRANSLATE8) +RTS -K32M
 
 # Without dependencies:
 Translate10:
@@ -44,13 +63,10 @@ Translate11.pgf: $(TRANSLATE11)
 	$(GFMKT) -name=Translate11 $(TRANSLATE11) +RTS -K32M
 
 # Without dependencies:
-Translate8:
-	$(GFMKT) -name=Translate8 $(TRANSLATE8) +RTS -K32M
+Translate15:
+	$(GFMKT) -name=Translate15 $(TRANSLATE15) +RTS -K32M
 
 # With dependencies:
-Translate8.pgf: $(TRANSLATE8)
-	$(GFMKT) -name=Translate8 $(TRANSLATE8) +RTS -K32M
-
 Translate15.pgf: $(TRANSLATE15)
 	$(GFMKT) -name=Translate15 $(TRANSLATE15) +RTS -K32M
 
@@ -71,13 +87,19 @@ TranslateCat.pgf:: ; $(GFMKT) -name=TranslateCat translator/TranslateCat.gf +RTS
 TranslateEst.pgf:: ; $(GFMKT) -name=TranslateEst translator/TranslateEst.gf +RTS -K64M
 TranslateTha.pgf:: ; $(GFMKT) -name=TranslateTha translator/TranslateTha.gf +RTS -K64M
 TranslateJpn.pgf:: ; $(GFMKT) -name=TranslateJpn translator/TranslateJpn.gf +RTS -K64M
+TranslateRus.pgf:: ; $(GFMKT) -name=TranslateRus translator/TranslateRus.gf 
+TranslateUrd.pgf:: ; $(GFMKT) -name=TranslateUrd translator/TranslateUrd.gf 
 
 # Selected language pairs:
+TranslateEngBul: ; $(GFMKT) -name=TranslateEngBul TranslateEng.pgf TranslateBul.pgf
+TranslateEngChi: ; $(GFMKT) -name=TranslateEngChi TranslateEng.pgf TranslateChi.pgf
 TranslateEngFin: ; $(GFMKT) -name=TranslateEngFin TranslateEng.pgf TranslateFin.pgf
 TranslateEngGer: ; $(GFMKT) -name=TranslateEngGer TranslateEng.pgf TranslateGer.pgf
 TranslateEngHin: ; $(GFMKT) -name=TranslateEngHin TranslateEng.pgf TranslateHin.pgf
-TranslateEngBul: ; $(GFMKT) -name=TranslateEngBul TranslateEng.pgf TranslateBul.pgf
-TranslateEngSpa: ; $(GFMKT) -name=TranslateEngSpa TranslateEng.pgf TranslateSpa.pgf
 TranslateEngFre: ; $(GFMKT) -name=TranslateEngFre TranslateEng.pgf TranslateFre.pgf
+TranslateEngSpa: ; $(GFMKT) -name=TranslateEngSpa TranslateEng.pgf TranslateSpa.pgf
 TranslateEngSwe: ; $(GFMKT) -name=TranslateEngSwe TranslateEng.pgf TranslateSwe.pgf
-TranslateEngChi: ; $(GFMKT) -name=TranslateEngChi TranslateEng.pgf TranslateChi.pgf
+
+# Selected language triplets
+TranslateEngSweFin: ; $(GFMKT) -name=TranslateEngSweFin TranslateEng.pgf TranslateSwe.pgf TranslateFin.pgf
+TranslateEngSweBul: ; $(GFMKT) -name=TranslateEngSweBul TranslateEng.pgf TranslateSwe.pgf TranslateBul.pgf

--- a/app/AppBul.gf
+++ b/app/AppBul.gf
@@ -1,4 +1,4 @@
---# -path=.:../../lib/src/chunk:../../lib/src/translator:../phrasebook/gfos
+--# -path=.:../chunk:../translator:../phrasebook/gfos
 
 concrete AppBul of App = 
 

--- a/app/AppCat.gf
+++ b/app/AppCat.gf
@@ -1,4 +1,4 @@
---# -path=.:../../lib/src/chunk:../../lib/src/translator:../phrasebook/gfos
+--# -path=.:../chunk:../translator:../phrasebook/gfos
 
 concrete AppCat of App = 
 

--- a/app/AppDut.gf
+++ b/app/AppDut.gf
@@ -1,4 +1,4 @@
---# -path=.:../../lib/src/chunk:../../lib/src/translator:../phrasebook/gfos
+--# -path=.:../chunk:../translator:../phrasebook/gfos
 
 concrete AppDut of App = 
 

--- a/app/AppEng.gf
+++ b/app/AppEng.gf
@@ -1,4 +1,4 @@
---# -path=.:../../lib/src/chunk:../../lib/src/translator:../phrasebook/gfos
+--# -path=.:../chunk:../translator:../phrasebook/gfos
 
 concrete AppEng of App = 
 

--- a/app/AppEst.gf
+++ b/app/AppEst.gf
@@ -1,4 +1,4 @@
---# -path=.:../../lib/src/chunk:../../lib/src/translator:../../lib/src/estonian:../phrasebook/gfos:alltenses
+--# -path=.:../chunk:../translator:../../lib/src/estonian:../phrasebook/gfos:alltenses
 
 concrete AppEst of App = 
 

--- a/app/AppFin.gf
+++ b/app/AppFin.gf
@@ -1,4 +1,4 @@
---# -path=.:../../lib/src/chunk:../../lib/src/finnish/stemmed:../../lib/src/finnish:../../lib/src/api:../../lib/src/translator:../phrasebook/gfos:alltenses
+--# -path=.:../chunk:../../lib/src/finnish/stemmed:../../lib/src/finnish:../../lib/src/api:../lib/src/translator:../phrasebook/gfos:alltenses
 
 concrete AppFin of App = 
 

--- a/app/AppFre.gf
+++ b/app/AppFre.gf
@@ -1,4 +1,4 @@
---# -path=.:../../lib/src/chunk:../../lib/src/translator:../phrasebook/gfos
+--# -path=.:../chunk:../translator:../phrasebook/gfos
 
 concrete AppFre of App = 
   TranslateFre - [

--- a/app/AppGer.gf
+++ b/app/AppGer.gf
@@ -1,4 +1,4 @@
---# -path=.:../../lib/src/chunk:../../lib/src/translator:../phrasebook/gfos:alltenses::../../lib/src/german
+--# -path=.:../chunk:../translator:../phrasebook/gfos:alltenses::../../lib/src/german
 
 concrete AppGer of App = 
 

--- a/app/AppHin.gf
+++ b/app/AppHin.gf
@@ -1,4 +1,4 @@
---# -path=.:../../lib/src/chunk:../../lib/src/translator:../phrasebook/gfos
+--# -path=.:../chunk:../translator:../phrasebook/gfos
 
 concrete AppHin of App = 
 

--- a/app/AppIta.gf
+++ b/app/AppIta.gf
@@ -1,4 +1,4 @@
---# -path=.:../../lib/src/chunk:../../lib/src/translator:../phrasebook/gfos
+--# -path=.:../chunk:../translator:../phrasebook/gfos
 
 concrete AppIta of App = 
 

--- a/app/AppJpn.gf
+++ b/app/AppJpn.gf
@@ -1,4 +1,4 @@
---# -path=.:../../lib/src/chunk:../../lib/src/translator:../phrasebook/gfos
+--# -path=.:../chunk:../translator:../phrasebook/gfos
 
 concrete AppJpn of App = 
 

--- a/app/AppRus.gf
+++ b/app/AppRus.gf
@@ -1,4 +1,4 @@
---# -path=.:../../lib/src/chunk:../../lib/src/translator:../phrasebook/gfos
+--# -path=.:../chunk:../translator:../phrasebook/gfos
 
 concrete AppRus of App = 
 

--- a/app/AppSpa.gf
+++ b/app/AppSpa.gf
@@ -1,4 +1,4 @@
---# -path=.:../../lib/src/chunk:../../lib/src/translator:../phrasebook/gfos
+--# -path=.:../chunk:../translator:../phrasebook/gfos
 
 
 concrete AppSpa of App = 

--- a/app/AppSwe.gf
+++ b/app/AppSwe.gf
@@ -1,4 +1,4 @@
---# -path=.:../../lib/src/chunk:../../lib/src/translator:../phrasebook/gfos
+--# -path=.:../chunk:../translator:../phrasebook/gfos
 
 concrete AppSwe of App = 
   TranslateSwe - [

--- a/app/AppTha.gf
+++ b/app/AppTha.gf
@@ -1,4 +1,4 @@
---# -path=.:../../lib/src/chunk:../../lib/src/translator:../phrasebook/gfos
+--# -path=.:../chunk:../translator:../phrasebook/gfos
 
 concrete AppTha of App = 
 

--- a/app/AppUrd.gf
+++ b/app/AppUrd.gf
@@ -1,4 +1,4 @@
---# -path=.:../../lib/src/chunk:../../lib/src/translator:../phrasebook/gfos
+--# -path=.:../chunk:../translator:../phrasebook/gfos
 
 concrete AppUrd of App = 
 

--- a/translator/ExtensionsBul.gf
+++ b/translator/ExtensionsBul.gf
@@ -1,7 +1,7 @@
 --# -path=.:../abstract
 
 concrete ExtensionsBul of Extensions = 
-  CatBul ** open ResBul, (E = ExtraBul), Prelude, SyntaxBul in {
+  CatBul ** open ResBul, (E = ExtraBul), (X = ExtendBul), Prelude, SyntaxBul in {
 
 flags 
   coding = utf8 ;
@@ -34,9 +34,24 @@ lin
   PassAgentVPSlash = E.PassAgentVPSlash ;
 
   EmptyRelSlash = E.EmptyRelSlash ;
+  
+  CompoundN  = X.CompoundN  ;
+  CompoundAP = X.CompoundAP ;
+  GerundCN   = X.GerundCN   ; 
+  GerundNP   = X.GerundNP   ;
+  GerundAdv  = X.GerundAdv  ; 
+  PresPartAP = X.PresPartAP ;
+  PastPartAP = X.PastPartAP ; 
+  PastPartAgentAP = X.PastPartAgentAP ; 
+  ByVP = X.ByVP ; 
+  InOrderToVP = X.InOrderToVP ; 
+  
+  PositAdVAdj = X.PositAdVAdj ; 
 
 lin
-  CompoundN noun cn = {
+
+{-
+    CompoundN noun cn = {
     s = \\nf => (noun.rel ! nform2aform nf cn.g) ++ (cn.s ! (indefNForm nf)) ;
     rel = \\af => (noun.rel ! af) ++ (cn.rel ! af) ; ---- is this correct? AR 29/5/2014
     g = cn.g
@@ -64,6 +79,7 @@ lin
     {s = vp.ad.s ++
          vp.s ! Imperf ! VGerund ++
          vp.compl ! {gn=GSg Neut; p=P3}} ;
+
 
   PresPartAP vp =
     let ap : AForm => Str
@@ -93,6 +109,8 @@ lin
                         "от" ++ np.s ! RObj Acc
     in {s = ap; adv = ap ! ASg Neut Indef; isPre = True} ;
 
+
+
   ByVP vp =
     {s = vp.ad.s ++
          vp.s ! Imperf ! VGerund ++
@@ -101,11 +119,13 @@ lin
   InOrderToVP vp =
     {s = "за" ++ daComplex Simul Pos (vp**{vtype=VMedial Acc}) ! Imperf ! {gn=GSg Neut; p=P3}};
 
+  PositAdVAdj a = {s = a.adv} ;
+  
+-}
+
   WithoutVP vp =
     {s = "без" ++ daComplex Simul Pos (vp**{vtype=VMedial Acc}) ! Imperf ! {gn=GSg Neut; p=P3}};
 
-  PositAdVAdj a = {s = a.adv} ;
-  
   that_RP = {
     s = whichRP
   } ;
@@ -179,7 +199,8 @@ lin
          compl2 = vp.compl;
          vtype  = vp.vtype;
          p      = vp.p;
-         c2     = {s=""; c=Acc}
+         c2     = {s=""; c=Acc};
+	 isSimple = vp.isSimple; 
        } ;
 
   ApposNP np1 np2 = {
@@ -189,7 +210,8 @@ lin
   } ;
 
   UttAdV adv = adv;
-  AdAdV = cc2 ;
+--  AdAdV = cc2 ;
+  AdAdV = X.AdAdV ; 
   
   DirectComplVS t np vs utt = 
     mkS (lin Adv (optCommaSS utt)) (mkS t positivePol (mkCl np (lin V vs))) ;

--- a/translator/ExtensionsDut.gf
+++ b/translator/ExtensionsDut.gf
@@ -1,7 +1,7 @@
 --# -path=.:../abstract
 
 concrete ExtensionsDut of Extensions = 
-  CatDut ** open ResDut, ParadigmsDut, SyntaxDut, (E = ExtraDut), ExtendDut, (G = GrammarDut), Prelude in {
+  CatDut ** open ResDut, ParadigmsDut, SyntaxDut, (E = ExtraDut), (X = ExtendDut), (G = GrammarDut), Prelude in {
 
 flags literal=Symb ; coding = utf8 ;
 
@@ -95,7 +95,7 @@ lin
     s = "door" ++ useInfVP False vp ! agrP3 Sg ----
     } ;
 
-  PastPartAP = ExtendDut.PastPartAP ;
+  PastPartAP = X.PastPartAP ;
   
   PresPartAP vp = { --# notpresent
     s = \\agr,af => let aForm = case vp.isHeavy of { --# notpresent
@@ -107,7 +107,7 @@ lin
 
   PastPartAgentAP vp np = 
     let agent = (SyntaxDut.mkAdv (mkPrep "door") (lin NP np)).s ;
-        ap = ExtendDut.PastPartAP vp ;
+        ap = X.PastPartAP vp ;
     in ap ** { s = \\agr,af => ap.s ! agr ! af ++ agent } ;
 
 {-  


### PR DESCRIPTION
Makes minor changes to the Makefile to compile the Translate grammar. At the moment, Bulgarian, Chinese and Finnish do not compile. Finnish due to external dependencies and Bulgarian and Chinese due to ongoing / recent changes to underlying RGL grammars. 

TODO: Also replace functions in the Extensions module in this grammar with the more central Extend module from RGL. I started doing this with Bulgarian but still more things to be done. 