### PR TITLE
Path fixes to translator grammar after GF repo split

### DIFF
--- a/translator/DictionaryBul.gf
+++ b/translator/DictionaryBul.gf
@@ -1,7 +1,8 @@
-concrete DictionaryBul of Dictionary = CatBul ** open MorphoBul, ResBul, (S = StructuralBul), (E = ExtraBul), ParadigmsBul, Prelude in {
-
-flags
-  coding=utf8 ;
+concrete DictionaryBul of Dictionary = 
+  CatBul 
+    ** open MorphoBul, ResBul, (S = StructuralBul), (E = ExtraBul), ParadigmsBul, Prelude in 
+{
+flags coding=utf8 ;
 
 --oper prepV2 : V -> Prep -> V2 = \v,p -> mkV2 v p ;
 oper advV : V -> Adv -> V = \v,_ -> v ; ----

--- a/translator/DictionaryEst.gf
+++ b/translator/DictionaryEst.gf
@@ -1,4 +1,4 @@
---# -path=.:../estonian
+--# -path=.:../gflibsrc/estonian:
 concrete DictionaryEst of Dictionary = CatEst ** open ParadigmsEst,
 (D = DictEst),
 (S = StructuralEst),

--- a/translator/DictionaryFin.gf
+++ b/translator/DictionaryFin.gf
@@ -1,4 +1,4 @@
---# -path=.:../finnish/stemmed:../finnish:../abstract:../common:../finnish/kotus:../api
+--# -path=.:../gflibsrc/finnish/stemmed:../gflibsrc/finnish:../gflibsrc/abstract:../gflibsrc/common:../gflibsrc/finnish/kotus:../gflibsrc/api:
 ---- checked by AR till beginning_N in the BNC order
 concrete DictionaryFin of Dictionary = CatFin ** open ParadigmsFin,
   (S = StructuralFin),

--- a/translator/DictionaryGer.gf
+++ b/translator/DictionaryGer.gf
@@ -1,4 +1,4 @@
--- -- # -path=.:../chunk:alltenses:../german
+-- -- # -path=.:../chunk:alltenses:../gflibsrc/german
 ---- edited by SS till cold_A and some in the 100 underneath
 
 concrete DictionaryGer of Dictionary = CatGer ** 

--- a/translator/DictionaryMlt.gf
+++ b/translator/DictionaryMlt.gf
@@ -1,4 +1,4 @@
---# -path=.:../maltese
+--# -path=.:../gflibsrc/maltese
 
 -- Maltese translation dictionary
 -- started by Aarne Ranta 2015

--- a/translator/ExtensionsBul.gf
+++ b/translator/ExtensionsBul.gf
@@ -1,4 +1,4 @@
---# -path=.:../abstract
+--# -path=.:../gflibsrc/abstract
 
 concrete ExtensionsBul of Extensions = 
   CatBul ** open ResBul, (E = ExtraBul), (X = ExtendBul), Prelude, SyntaxBul in {

--- a/translator/ExtensionsChi.gf
+++ b/translator/ExtensionsChi.gf
@@ -1,4 +1,4 @@
---# -path=.:../abstract
+--# -path=.:../gflibsrc/abstract
 
 concrete ExtensionsChi of Extensions = 
   CatChi ** open ResChi, ParadigmsChi, SyntaxChi, (G = GrammarChi), (E = ExtraChi), Prelude in {

--- a/translator/ExtensionsDut.gf
+++ b/translator/ExtensionsDut.gf
@@ -1,4 +1,4 @@
---# -path=.:../abstract
+--# -path=.:../gflibsrc/abstract
 
 concrete ExtensionsDut of Extensions = 
   CatDut ** open ResDut, ParadigmsDut, SyntaxDut, (E = ExtraDut), (X = ExtendDut), (G = GrammarDut), Prelude in {

--- a/translator/ExtensionsEng.gf
+++ b/translator/ExtensionsEng.gf
@@ -1,4 +1,4 @@
---# -path=.:../abstract
+--# -path=.:../gflibsrc/abstract
 
 concrete ExtensionsEng of Extensions = 
   CatEng ** open MorphoEng, ResEng, ParadigmsEng, (S = SentenceEng), (E = ExtraEng), SyntaxEng, Prelude in {

--- a/translator/ExtensionsEst.gf
+++ b/translator/ExtensionsEst.gf
@@ -1,4 +1,4 @@
---# -path=.:../abstract
+--# -path=.:../gflibsrc/abstract
 
 concrete ExtensionsEst of Extensions = 
   CatEst ** open MorphoEst, ResEst, ParadigmsEst, SyntaxEst, (G = GrammarEst), (E = ExtraEst), Prelude in {

--- a/translator/ExtensionsFin.gf
+++ b/translator/ExtensionsFin.gf
@@ -1,4 +1,4 @@
---# -path=.:../abstract
+--# -path=.:../gflibsrc/abstract
 
 concrete ExtensionsFin of Extensions = 
   CatFin ** open MorphoFin, ResFin, ParadigmsFin, SyntaxFin, (G = GrammarFin), (E = ExtraFin), StemFin, Prelude in {

--- a/translator/ExtensionsGer.gf
+++ b/translator/ExtensionsGer.gf
@@ -1,4 +1,4 @@
---# -path=.:../abstract
+--# -path=.:../gflibsrc/abstract
 
 concrete ExtensionsGer of Extensions = 
   CatGer ** open MorphoGer, ResGer, ParadigmsGer, SyntaxGer, (E = ExtraGer), (G = GrammarGer), Prelude in {

--- a/translator/ExtensionsHin.gf
+++ b/translator/ExtensionsHin.gf
@@ -1,4 +1,4 @@
---# -path=.:../abstract
+--# -path=.:../gflibsrc/abstract
 
 concrete ExtensionsHin of Extensions = 
   CatHin ** open MorphoHin, ResHin, ParadigmsHin, CommonHindustani, (E = ExtraHin), Prelude in {

--- a/translator/ExtensionsJpn.gf
+++ b/translator/ExtensionsJpn.gf
@@ -1,4 +1,4 @@
---# -path=.:../abstract
+--# -path=.:../gflibsrc/abstract
 
 concrete ExtensionsJpn of Extensions = 
   CatJpn ** open ResJpn, ParadigmsJpn, SyntaxJpn, (G = GrammarJpn), (E = ExtraJpn), Prelude in {

--- a/translator/ExtensionsRus.gf
+++ b/translator/ExtensionsRus.gf
@@ -1,4 +1,4 @@
---# -path=.:../abstract
+--# -path=.:../gflibsrc/abstract
 
 concrete ExtensionsRus of Extensions = 
   CatRus ** open ResRus, (E = ExtraRus), Prelude, SyntaxRus in {

--- a/translator/ExtensionsSwe.gf
+++ b/translator/ExtensionsSwe.gf
@@ -1,4 +1,4 @@
---# -path=.:../abstract
+--# -path=.:../gflibsrc/abstract
 
 concrete ExtensionsSwe of Extensions = 
   CatSwe ** open MorphoSwe, ResSwe, ParadigmsSwe, (E = ExtraSwe), (G = GrammarSwe), SyntaxSwe, CommonScand, Prelude in {

--- a/translator/ExtensionsTha.gf
+++ b/translator/ExtensionsTha.gf
@@ -1,4 +1,4 @@
---# -path=.:../abstract
+--# -path=.:../gflibsrc/abstract
 
 concrete ExtensionsTha of Extensions = 
   CatTha ** open ResTha, ParadigmsTha, SyntaxTha, (G = GrammarTha), Prelude in {

--- a/translator/ExtensionsUrd.gf
+++ b/translator/ExtensionsUrd.gf
@@ -1,4 +1,4 @@
---# -path=.:../abstract
+--# -path=.:../gflibsrc/abstract
 
 concrete ExtensionsUrd of Extensions = 
   CatUrd ** open MorphoUrd, ResUrd, ParadigmsUrd, CommonHindustani, (E = ExtraUrd), Prelude in {

--- a/translator/TranslateEst.gf
+++ b/translator/TranslateEst.gf
@@ -1,4 +1,4 @@
---# -path=.:../chunk:../estonian
+--# -path=.:../chunk:../gflibsrc/estonian
 
 concrete TranslateEst of Translate = 
   TenseX,

--- a/translator/TranslateEus.gf
+++ b/translator/TranslateEus.gf
@@ -1,4 +1,4 @@
---# -path=.:../chunk:alltenses:../basque
+--# -path=.:../chunk:alltenses:../gflibsrc/basque
 
 concrete TranslateEus of Translate = 
   TenseX,

--- a/translator/TranslateFin.gf
+++ b/translator/TranslateFin.gf
@@ -1,4 +1,4 @@
---# -path=.:../chunk:../finnish/stemmed:../finnish:../api
+--# -path=.:../chunk:../gflibsrc/finnish/stemmed:../gflibsrc/finnish:../gflibsrc/api
 
 concrete TranslateFin of Translate = 
   TenseX,

--- a/translator/TranslateGer.gf
+++ b/translator/TranslateGer.gf
@@ -1,4 +1,4 @@
---# -path=.:../chunk:alltenses:../german
+--# -path=.:../chunk:alltenses:../gflibsrc/german
 
 concrete TranslateGer of Translate = 
   TenseGer,


### PR DESCRIPTION
This patch fixes the paths used in grammars by assuming there is a symlink gflibsrc in the top-level directory to the RGL source. This is a quick fix and might need to be addressed at a later time.